### PR TITLE
Implementation of configuration via files

### DIFF
--- a/py/cy_vysmaw.pyx
+++ b/py/cy_vysmaw.pyx
@@ -66,8 +66,15 @@ def show_properties(instance, klass):
 
 cdef class Configuration:
 
-    def __cinit__(self):
-        self._c_configuration = vysmaw_configuration_new()
+    def __cinit__(self, path=None):
+        cdef char *cpath
+        apath = None
+        if path is not None:
+            apath = _ustring(path).encode('ascii')
+            cpath = apath
+        else:
+            cpath = NULL
+        self._c_configuration = vysmaw_configuration_new(cpath)
         if self._c_configuration is NULL:
             raise MemoryError()
         return

--- a/py/vysmaw.pxd
+++ b/py/vysmaw.pxd
@@ -126,7 +126,7 @@ cdef extern from "vysmaw.h":
                                unsigned num_consumers,
                                vysmaw_consumer **consumers) nogil
 
-    vysmaw_configuration *vysmaw_configuration_new() nogil
+    vysmaw_configuration *vysmaw_configuration_new(char *path) nogil
 
     void vysmaw_configuration_free(vysmaw_configuration *config)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,6 @@ target_compile_options(vys PRIVATE
   ${GLIB2_CLFAGS_OTHER})
 target_compile_definitions(vys PRIVATE
   VYS_CONFIG_PATH="${CMAKE_INSTALL_PREFIX}/etc/vys.conf"
-  VYS_CONFIG_GROUP_NAME="vys"
   VYS_SIGNAL_MULTICAST_ADDRESS="224.0.0.100")
 target_link_libraries(vys
   ${GLIB2_LIBRARIES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,11 +2,29 @@ find_package(Verbs REQUIRED)
 find_package(RDMACM REQUIRED)
 find_package(PkgConfig REQUIRED)
 
+pkg_check_modules(GLIB2 REQUIRED glib-2.0)
 pkg_check_modules(GTHREAD2 REQUIRED gthread-2.0)
 
 set(CMAKE_C_FLAGS
   "${CMAKE_C_FLAGS} -Wall -Werror")
 
+# vys library
+add_library(vys SHARED
+  vys.c)
+target_include_directories(vys PRIVATE
+  ${GLIB2_INCLUDE_DIRS}
+  .)
+target_compile_options(vys PRIVATE
+  ${GLIB2_CFLAGS}
+  ${GLIB2_CLFAGS_OTHER})
+target_compile_definitions(vys PRIVATE
+  VYS_CONFIG_PATH="${CMAKE_INSTALL_PREFIX}/etc/vys.conf"
+  VYS_CONFIG_GROUP_NAME="vys"
+  VYS_SIGNAL_MULTICAST_ADDRESS="224.0.0.100")
+target_link_libraries(vys
+  ${GLIB2_LIBRARIES})
+
+# vysmaw library
 add_library(vysmaw SHARED
   vysmaw_private.c
   buffer_pool.c
@@ -14,16 +32,14 @@ add_library(vysmaw SHARED
   spectrum_selector.c
   spectrum_reader.c
   vysmaw.c)
-
-include_directories(
+target_include_directories(vysmaw PRIVATE
   ${GTHREAD2_INCLUDE_DIRS}
   .)
-add_compile_options(
+target_compile_options(vysmaw PRIVATE
   ${GTHREAD2_CFLAGS}
   ${GTHREAD2_CLFAGS_OTHER})
-
-target_link_libraries(
-  vysmaw
+target_link_libraries(vysmaw
+  vys
   ${GTHREAD2_LIBRARIES}
   ${VERBS_LIBRARY}
   ${RDMACM_LIBRARY})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_C_FLAGS
 
 # vys library
 add_library(vys SHARED
+  vys_private.c
   vys.c)
 target_include_directories(vys PRIVATE
   ${GLIB2_INCLUDE_DIRS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,8 @@ target_include_directories(vysmaw PRIVATE
 target_compile_options(vysmaw PRIVATE
   ${GTHREAD2_CFLAGS}
   ${GTHREAD2_CLFAGS_OTHER})
+target_compile_definitions(vysmaw PRIVATE
+  VYSMAW_CONFIG_PATH="${CMAKE_INSTALL_PREFIX}/etc/vysmaw.conf")
 target_link_libraries(vysmaw
   vys
   ${GTHREAD2_LIBRARIES}

--- a/src/spectrum_reader.c
+++ b/src/spectrum_reader.c
@@ -101,10 +101,12 @@ static int compare_server_comp_ch_fd(
 	void *unused __attribute__((unused)))
 	__attribute__((nonnull,pure));
 static int start_rdma_cm(
-	struct spectrum_reader_context_ *context, GSList **error_records)
+	struct spectrum_reader_context_ *context,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int stop_rdma_cm(
-	struct spectrum_reader_context_ *context, GSList **error_records)
+	struct spectrum_reader_context_ *context,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static void set_max_posted_wr(
 	struct spectrum_reader_context_ *context,
@@ -112,37 +114,41 @@ static void set_max_posted_wr(
 	__attribute__((nonnull));
 static struct server_connection_context *initiate_server_connection(
 	struct spectrum_reader_context_ *context, const struct sockaddr_in *sockaddr,
-	GSList **error_records)
+	struct vys_error_record **error_record)
 	__attribute__((nonnull,returns_nonnull,malloc));
 static int find_connection(
 	struct spectrum_reader_context_ *context, struct sockaddr_in *sockaddr,
 	struct server_connection_context **conn_ctx, GQueue **req_queue,
-	GSList **error_records)
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int on_signal_message(
 	struct spectrum_reader_context_ *context, struct signal_msg *msg,
-	GSList **consumers, GSList **error_records)
+	GSList **consumers, struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int on_data_path_message(
 	struct spectrum_reader_context_ *context, struct data_path_message *msg,
-	GSList **error_records)
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int on_server_addr_resolved(
 	struct spectrum_reader_context_ *context,
-	struct server_connection_context *conn_ctx, GSList **error_records)
+	struct server_connection_context *conn_ctx,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int on_server_route_resolved(
 	struct spectrum_reader_context_ *context,
-	struct server_connection_context *conn_ctx, GSList **error_records)
+	struct server_connection_context *conn_ctx,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int post_server_reads(
 	struct spectrum_reader_context_ *context,
-	struct server_connection_context *conn_ctx, GSList **error_records)
+	struct server_connection_context *conn_ctx,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int on_server_established(
 	struct spectrum_reader_context_ *context,
 	struct server_connection_context *conn_ctx, uint32_t rkey,
-	unsigned initiator_depth, GSList **error_records)
+	unsigned initiator_depth,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static GSequenceIter *find_server_connection_context_iter(
 	const struct spectrum_reader_context_ *context, int fd)
@@ -152,18 +158,21 @@ static struct server_connection_context *find_server_connection_context(
 	__attribute__((nonnull));
 static int begin_server_disconnect(
 	struct spectrum_reader_context_ *context,
-	struct server_connection_context *conn_ctx, GSList **error_records)
+	struct server_connection_context *conn_ctx,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int complete_server_disconnect(
 	struct spectrum_reader_context_ *context,
-	struct server_connection_context *conn_ctx, GSList **error_records)
+	struct server_connection_context *conn_ctx,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int on_cm_event(
-	struct spectrum_reader_context_ *context, GSList **error_records)
+	struct spectrum_reader_context_ *context,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int poll_completions(
 	GChecksum *checksum, struct server_connection_context *conn_ctx,
-	GSList **reqs, GSList **error_records)
+	GSList **reqs, struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static void ack_completions(
 	struct server_connection_context *conn_ctx, unsigned min_ack)
@@ -171,33 +180,39 @@ static void ack_completions(
 static int get_completed_requests(
 	struct spectrum_reader_context_ *context, int fd,
 	struct server_connection_context **conn_ctx, GSList **reqs,
-	GSList **error_records)
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int on_read_completion(
 	struct spectrum_reader_context_ *context, unsigned pfd,
-	GSList **error_records)
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int on_inactivity_timer_event(
-	struct spectrum_reader_context_ *context, GSList **error_records)
+	struct spectrum_reader_context_ *context,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int on_poll_events(
-	struct spectrum_reader_context_ *context, GSList **error_records)
+	struct spectrum_reader_context_ *context,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
-static int to_quit_state(struct spectrum_reader_context_ *context,
-                         struct data_path_message *msg, GSList **error_records)
+static int to_quit_state(
+	struct spectrum_reader_context_ *context,
+	struct data_path_message *msg, struct vys_error_record **error_record)
 	__attribute__((nonnull(1,3)));
 static int spectrum_reader_loop(
-	struct spectrum_reader_context_ *context, GSList **error_records)
+	struct spectrum_reader_context_ *context,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int start_inactivity_timer(
-	struct spectrum_reader_context_ *context, GSList **error_records)
+	struct spectrum_reader_context_ *context,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int stop_inactivity_timer(
-	struct spectrum_reader_context_ *context, GSList **error_records)
+	struct spectrum_reader_context_ *context,
+	struct vys_error_record **error_record)
 	__attribute__((nonnull));
 static int loopback_msg(
 	struct spectrum_reader_context_ *context,
-	struct data_path_message *msg, GSList **error_records)
+	struct data_path_message *msg, struct vys_error_record **error_record)
 	__attribute__((nonnull));
 
 static bool
@@ -245,17 +260,18 @@ compare_server_comp_ch_fd(const struct server_connection_context *c1,
 }
 
 static int
-start_rdma_cm(struct spectrum_reader_context_ *context, GSList **error_records)
+start_rdma_cm(struct spectrum_reader_context_ *context,
+              struct vys_error_record **error_record)
 {
 	/* rdma cm event channel */
 	context->event_channel = rdma_create_event_channel();
 	if (G_UNLIKELY(context->event_channel == NULL)) {
-		VERB_ERR(error_records, errno, "rdma_create_event_channel");
+		VERB_ERR(error_record, errno, "rdma_create_event_channel");
 		return -1;
 	}
 	int rc = set_nonblocking(context->event_channel->fd);
 	if (G_UNLIKELY(rc != 0)) {
-		MSG_ERROR(error_records, errno,
+		MSG_ERROR(error_record, errno,
 		          "failed to set rdma cm event channel to non-blocking: %s",
 		          strerror(errno));
 		return rc;
@@ -274,7 +290,8 @@ start_rdma_cm(struct spectrum_reader_context_ *context, GSList **error_records)
 }
 
 static int
-stop_rdma_cm(struct spectrum_reader_context_ *context, GSList **error_records)
+stop_rdma_cm(struct spectrum_reader_context_ *context,
+             struct vys_error_record **error_record)
 {
 	if (context->fd_connections != NULL)
 		g_sequence_free(context->fd_connections);
@@ -302,12 +319,12 @@ set_max_posted_wr(struct spectrum_reader_context_ *context,
 static struct server_connection_context *
 initiate_server_connection(struct spectrum_reader_context_ *context,
                            const struct sockaddr_in *sockaddr,
-                           GSList **error_records)
+                           struct vys_error_record **error_record)
 {
 	struct rdma_cm_id *id;
 	int rc = rdma_create_id(context->event_channel, &id, NULL, RDMA_PS_TCP);
 	if (G_UNLIKELY(rc != 0)) {
-		VERB_ERR(error_records, errno, "rdma_create_id");
+		VERB_ERR(error_record, errno, "rdma_create_id");
 		return NULL;
 	}
 
@@ -316,7 +333,7 @@ initiate_server_connection(struct spectrum_reader_context_ *context,
 		id, NULL, (struct sockaddr *)key,
 		context->shared->handle->config.resolve_addr_timeout_ms);
 	if (G_UNLIKELY(rc != 0)) {
-		VERB_ERR(error_records, errno, "rdma_resolve_addr");
+		VERB_ERR(error_record, errno, "rdma_resolve_addr");
 		rdma_destroy_id(id);
 		free_sockaddr_key(key);
 		return NULL;
@@ -342,12 +359,12 @@ static int
 find_connection(struct spectrum_reader_context_ *context,
                 struct sockaddr_in *sockaddr,
                 struct server_connection_context **conn_ctx,
-                GQueue **req_queue, GSList **error_records)
+                GQueue **req_queue, struct vys_error_record **error_record)
 {
 	*conn_ctx = g_hash_table_lookup(context->connections, sockaddr);
 	if (*conn_ctx == NULL) {
 		*conn_ctx =
-			initiate_server_connection(context, sockaddr, error_records);
+			initiate_server_connection(context, sockaddr, error_record);
 		if (G_UNLIKELY(*conn_ctx == NULL))
 			return -1;
 	}
@@ -362,14 +379,14 @@ find_connection(struct spectrum_reader_context_ *context,
 static int
 on_signal_message(struct spectrum_reader_context_ *context,
                   struct signal_msg *msg, GSList **consumers,
-                  GSList **error_records)
+                  struct vys_error_record **error_record)
 {
 	struct signal_msg_payload *payload = &(msg->payload);
 	GQueue *reqs = NULL;
 	struct server_connection_context *conn_ctx = NULL;
 
 	int rc = find_connection(context, &payload->sockaddr, &conn_ctx, &reqs,
-	                         error_records);
+	                         error_record);
 
 	if (G_LIKELY(rc == 0 && reqs != NULL)) {
 		struct vysmaw_spectrum_info *info = payload->infos;
@@ -388,14 +405,15 @@ on_signal_message(struct spectrum_reader_context_ *context,
 
 static int
 on_data_path_message(struct spectrum_reader_context_ *context,
-                     struct data_path_message *msg, GSList **error_records)
+                     struct data_path_message *msg,
+                     struct vys_error_record **error_record)
 {
 	int rc = 0;
 	switch (msg->typ) {
 	case DATA_PATH_SIGNAL_MSG:
 		if (G_LIKELY(context->state == STATE_RUN))
 			rc = on_signal_message(
-				context, msg->signal_msg, msg->consumers, error_records);
+				context, msg->signal_msg, msg->consumers, error_record);
 		buffer_pool_push(context->shared->signal_msg_buffers, msg->signal_msg);
 		data_path_message_free(msg);
 		break;
@@ -412,13 +430,13 @@ on_data_path_message(struct spectrum_reader_context_ *context,
 
 	case DATA_PATH_QUIT:
 		if (context->quit_msg == NULL) {
-			rc = to_quit_state(context, msg, error_records);
+			rc = to_quit_state(context, msg, error_record);
 		} else {
 			if (context->quit_msg == msg) {
 				context->end_msg = data_path_message_new(
 					context->shared->signal_msg_num_spectra);
 				context->end_msg->typ = DATA_PATH_END;
-				rc = loopback_msg(context, context->end_msg, error_records);
+				rc = loopback_msg(context, context->end_msg, error_record);
 				context->quit_msg = NULL;
 			}
 			data_path_message_free(msg);
@@ -439,13 +457,13 @@ on_data_path_message(struct spectrum_reader_context_ *context,
 static int
 on_server_addr_resolved(struct spectrum_reader_context_ *context,
                         struct server_connection_context *conn_ctx,
-                        GSList **error_records)
+                        struct vys_error_record **error_record)
 {
 	/* query ib device */
 	struct ibv_device_attr dev_attr;
 	int rc = ibv_query_device(conn_ctx->id->verbs, &dev_attr);
 	if (G_UNLIKELY(rc != 0)) {
-		VERB_ERR(error_records, rc, "ibv_query_device");
+		VERB_ERR(error_record, rc, "ibv_query_device");
 		return -1;
 	}
 	set_max_posted_wr(
@@ -463,7 +481,7 @@ on_server_addr_resolved(struct spectrum_reader_context_ *context,
 	attr.cap.max_recv_sge = 1;
 	rc = rdma_create_qp(conn_ctx->id, NULL, &attr);
 	if (G_UNLIKELY(rc != 0)) {
-		VERB_ERR(error_records, errno, "rdma_create_qp");
+		VERB_ERR(error_record, errno, "rdma_create_qp");
 		return -1;
 	}
 
@@ -474,7 +492,7 @@ on_server_addr_resolved(struct spectrum_reader_context_ *context,
 	/* resize cq for the maximum number of posted work requests */
 	rc = ibv_resize_cq(conn_ctx->id->send_cq, conn_ctx->max_posted_wr);
 	if (G_UNLIKELY(rc != 0)) {
-		VERB_ERR(error_records, errno, "ibv_resize_cq");
+		VERB_ERR(error_record, errno, "ibv_resize_cq");
 		return -1;
 	}
 
@@ -487,7 +505,7 @@ on_server_addr_resolved(struct spectrum_reader_context_ *context,
 		conn_ctx->id,
 		context->shared->handle->config.resolve_route_timeout_ms);
 	if (G_UNLIKELY(rc != 0))
-		VERB_ERR(error_records, errno, "rdma_resolve_route");
+		VERB_ERR(error_record, errno, "rdma_resolve_route");
 
 	return rc;
 
@@ -496,11 +514,11 @@ on_server_addr_resolved(struct spectrum_reader_context_ *context,
 static int
 on_server_route_resolved(struct spectrum_reader_context_ *context,
                          struct server_connection_context *conn_ctx,
-                         GSList **error_records)
+                         struct vys_error_record **error_record)
 {
 	/* register memory for receiving spectra */
 	conn_ctx->mrs = register_spectrum_buffer_pools(
-		context->shared->handle, conn_ctx->id, error_records);
+		context->shared->handle, conn_ctx->id, error_record);
 	if (G_UNLIKELY(conn_ctx->mrs == NULL))
 		return -1;
 
@@ -519,7 +537,7 @@ on_server_route_resolved(struct spectrum_reader_context_ *context,
 	/* post first request for notification from completion queue */
 	int rc = ibv_req_notify_cq(conn_ctx->id->send_cq, 0);
 	if (G_UNLIKELY(rc != 0)) {
-		VERB_ERR(error_records, rc, "ibv_req_notify_cq");
+		VERB_ERR(error_record, rc, "ibv_req_notify_cq");
 		return rc;
 	}
 
@@ -529,14 +547,14 @@ on_server_route_resolved(struct spectrum_reader_context_ *context,
 	conn_param.initiator_depth = conn_ctx->max_posted_wr;
 	rc = rdma_connect(conn_ctx->id, &conn_param);
 	if (G_UNLIKELY(rc != 0))
-		VERB_ERR(error_records, errno, "rdma_connect");
+		VERB_ERR(error_record, errno, "rdma_connect");
 	return rc;
 }
 
 static int
 post_server_reads(struct spectrum_reader_context_ *context,
                   struct server_connection_context *conn_ctx,
-                  GSList **error_records)
+                  struct vys_error_record **error_record)
 {
 	int rc = 0;
 	struct ibv_mr *mr = NULL;
@@ -560,7 +578,7 @@ post_server_reads(struct spectrum_reader_context_ *context,
 			if (G_LIKELY(rc == 0))
 				conn_ctx->num_posted_wr++;
 			else
-				VERB_ERR(error_records, errno, "rdma_post_read");
+				VERB_ERR(error_record, errno, "rdma_post_read");
 		} else {
 			free_rdma_req(req);
 		}
@@ -572,14 +590,14 @@ static int
 on_server_established(struct spectrum_reader_context_ *context,
                       struct server_connection_context *conn_ctx,
                       uint32_t rkey, unsigned initiator_depth,
-                      GSList **error_records)
+                      struct vys_error_record **error_record)
 {
 	conn_ctx->rkey = rkey;
 	set_max_posted_wr(context, conn_ctx,
 	                  MIN(conn_ctx->max_posted_wr, initiator_depth));
 	conn_ctx->wcs = g_new(struct ibv_wc, conn_ctx->max_posted_wr);
 	conn_ctx->established = true;
-	return post_server_reads(context, conn_ctx, error_records);
+	return post_server_reads(context, conn_ctx, error_record);
 }
 
 static GSequenceIter *
@@ -617,7 +635,7 @@ find_server_connection_context(const struct spectrum_reader_context_ *context,
 static int
 begin_server_disconnect(struct spectrum_reader_context_ *context,
                         struct server_connection_context *conn_ctx,
-                        GSList **error_records)
+                        struct vys_error_record **error_record)
 {
 	int rc = 0;
 	while (!g_queue_is_empty(conn_ctx->reqs))
@@ -627,7 +645,7 @@ begin_server_disconnect(struct spectrum_reader_context_ *context,
 		conn_ctx->established = false;
 		rc = rdma_disconnect(conn_ctx->id);
 		if (G_UNLIKELY(rc != 0))
-			VERB_ERR(error_records, errno, "rdma_disconnect");
+			VERB_ERR(error_record, errno, "rdma_disconnect");
 	}
 	return rc;
 }
@@ -635,7 +653,7 @@ begin_server_disconnect(struct spectrum_reader_context_ *context,
 static int
 complete_server_disconnect(struct spectrum_reader_context_ *context,
                            struct server_connection_context *conn_ctx,
-                           GSList **error_records)
+                           struct vys_error_record **error_record)
 {
 	if (conn_ctx->reqs != NULL)
 		g_queue_free(conn_ctx->reqs);
@@ -643,7 +661,7 @@ complete_server_disconnect(struct spectrum_reader_context_ *context,
 	bool removed = g_hash_table_remove(
 		context->connections, &(conn_ctx->id->route.addr.dst_sin));
 	if (G_UNLIKELY(!removed))
-		MSG_ERROR(error_records, -1, "%s",
+		MSG_ERROR(error_record, -1, "%s",
 		          "failed to remove server connection record from client");
 
 	g_sequence_remove(
@@ -672,7 +690,7 @@ complete_server_disconnect(struct spectrum_reader_context_ *context,
 		              void *unused1) {
 			int rc = rdma_dereg_mr(mr);
 			if (G_UNLIKELY(rc != 0))
-				VERB_ERR(error_records, errno, "rdma_dereg_mr");
+				VERB_ERR(error_record, errno, "rdma_dereg_mr");
 		}
 		g_hash_table_foreach(conn_ctx->mrs, (GHFunc)dereg_mr, NULL);
 		g_hash_table_destroy(conn_ctx->mrs);
@@ -680,7 +698,7 @@ complete_server_disconnect(struct spectrum_reader_context_ *context,
 
 	int rc = rdma_destroy_id(conn_ctx->id);
 	if (G_UNLIKELY(rc != 0))
-		VERB_ERR(error_records, errno, "rdma_destroy_id");
+		VERB_ERR(error_record, errno, "rdma_destroy_id");
 
 	if (conn_ctx->wcs != NULL)
 		g_free(conn_ctx->wcs);
@@ -690,17 +708,18 @@ complete_server_disconnect(struct spectrum_reader_context_ *context,
 
 	g_slice_free(struct server_connection_context, conn_ctx);
 
-	return ((*error_records != NULL) ? -1 : 0);
+	return ((*error_record != NULL) ? -1 : 0);
 }
 
 static int
-on_cm_event(struct spectrum_reader_context_ *context, GSList **error_records)
+on_cm_event(struct spectrum_reader_context_ *context,
+            struct vys_error_record **error_record)
 {
 	/* get event */
 	struct rdma_cm_event *event = NULL;
 	int rc = rdma_get_cm_event(context->event_channel, &event);
 	if (G_UNLIKELY(rc != 0)) {
-		VERB_ERR(error_records, errno, "rdma_get_cm_event");
+		VERB_ERR(error_record, errno, "rdma_get_cm_event");
 		return rc;
 	}
 
@@ -710,7 +729,7 @@ on_cm_event(struct spectrum_reader_context_ *context, GSList **error_records)
 		                    &event->id->route.addr.dst_sin);
 	if (G_UNLIKELY(conn_ctx == NULL))
 		MSG_ERROR(
-			error_records, -1,
+			error_record, -1,
 			"failed to find connection for event %s",
 			rdma_event_str(event->event));
 
@@ -725,31 +744,31 @@ on_cm_event(struct spectrum_reader_context_ *context, GSList **error_records)
 	/* ack event */
 	rc = rdma_ack_cm_event(event);
 	if (G_UNLIKELY(rc != 0))
-		VERB_ERR(error_records, errno, "rdma_ack_cm_event");
+		VERB_ERR(error_record, errno, "rdma_ack_cm_event");
 
-	if (G_UNLIKELY(*error_records != NULL))
+	if (G_UNLIKELY(*error_record != NULL))
 		return -1;
 
 	/* dispatch event based on type */
 	switch (ev_type) {
 	case RDMA_CM_EVENT_ADDR_RESOLVED:
-		rc = on_server_addr_resolved(context, conn_ctx, error_records);
+		rc = on_server_addr_resolved(context, conn_ctx, error_record);
 		break;
 
 	case RDMA_CM_EVENT_ROUTE_RESOLVED:
-		rc = on_server_route_resolved(context, conn_ctx, error_records);
+		rc = on_server_route_resolved(context, conn_ctx, error_record);
 		break;
 
 	case RDMA_CM_EVENT_ESTABLISHED: {
 		uint32_t rkey = *(uint32_t *)private_data;
 		rc = on_server_established(context, conn_ctx, rkey, initiator_depth,
-		                           error_records);
+		                           error_record);
 		break;
 	}
 	case RDMA_CM_EVENT_DISCONNECTED:
-		rc = begin_server_disconnect(context, conn_ctx, error_records);
+		rc = begin_server_disconnect(context, conn_ctx, error_record);
 		if (rc == 0 && conn_ctx->num_posted_wr == 0)
-			rc = complete_server_disconnect(context, conn_ctx, error_records);
+			rc = complete_server_disconnect(context, conn_ctx, error_record);
 		break;
 
 	case RDMA_CM_EVENT_ADDR_ERROR:
@@ -760,7 +779,7 @@ on_cm_event(struct spectrum_reader_context_ *context, GSList **error_records)
 		char addr[INET_ADDRSTRLEN];
 		inet_ntop(AF_INET, &(conn_ctx->id->route.addr.dst_sin),
 		          addr, sizeof(addr));
-		MSG_ERROR(error_records, -1, "%s on %s", rdma_event_str(ev_type), addr);
+		MSG_ERROR(error_record, -1, "%s on %s", rdma_event_str(ev_type), addr);
 		rc = -1;
 		break;
 	}
@@ -773,13 +792,13 @@ on_cm_event(struct spectrum_reader_context_ *context, GSList **error_records)
 
 static int
 poll_completions(GChecksum *checksum, struct server_connection_context *conn_ctx,
-                 GSList **reqs, GSList **error_records)
+                 GSList **reqs, struct vys_error_record **error_record)
 {
 	*reqs = NULL;
 	int nc = ibv_poll_cq(conn_ctx->id->send_cq, conn_ctx->max_posted_wr,
 	                     conn_ctx->wcs);
 	if (G_UNLIKELY(nc < 0)) {
-		VERB_ERR(error_records, errno, "ibv_poll_cq");
+		VERB_ERR(error_record, errno, "ibv_poll_cq");
 		return errno;
 	}
 	if (G_LIKELY(nc > 0)) {
@@ -819,12 +838,12 @@ ack_completions(struct server_connection_context *conn_ctx, unsigned min_ack)
 static int
 get_completed_requests(struct spectrum_reader_context_ *context, int fd,
                        struct server_connection_context **conn_ctx,
-                       GSList **reqs, GSList **error_records)
+                       GSList **reqs, struct vys_error_record **error_record)
 {
 	/* look up server_connection_context instance for given fd */
 	*conn_ctx = find_server_connection_context(context, fd);
 	if (G_UNLIKELY(*conn_ctx == NULL)) {
-		MSG_ERROR(error_records, -1,
+		MSG_ERROR(error_record, -1,
 		          "failed to find server context for read completion on %d",
 		          fd);
 		return -1;
@@ -835,7 +854,7 @@ get_completed_requests(struct spectrum_reader_context_ *context, int fd,
 	int rc =
 		ibv_get_cq_event((*conn_ctx)->id->send_cq_channel, &ev_cq, &cq_ctx);
 	if (G_UNLIKELY(rc != 0)) {
-		VERB_ERR(error_records, errno, "ibv_get_cq_event");
+		VERB_ERR(error_record, errno, "ibv_get_cq_event");
 		return rc;
 	}
 
@@ -844,16 +863,16 @@ get_completed_requests(struct spectrum_reader_context_ *context, int fd,
 
 	rc = ibv_req_notify_cq(ev_cq, 0);
 	if (G_UNLIKELY(rc != 0)) {
-		VERB_ERR(error_records, rc, "ibv_req_notify_cq");
+		VERB_ERR(error_record, rc, "ibv_req_notify_cq");
 		return rc;
 	}
 
-	return poll_completions(context->checksum, *conn_ctx, reqs, error_records);
+	return poll_completions(context->checksum, *conn_ctx, reqs, error_record);
 }
 
 static int
 on_read_completion(struct spectrum_reader_context_ *context, unsigned pfd,
-                   GSList **error_records)
+                   struct vys_error_record **error_record)
 {
 	struct pollfd *pollfd =
 		&g_array_index(context->pollfds, struct pollfd, pfd);
@@ -861,12 +880,12 @@ on_read_completion(struct spectrum_reader_context_ *context, unsigned pfd,
 	GSList *reqs = NULL;
 	struct server_connection_context *conn_ctx;
 	int rc = get_completed_requests(context, pollfd->fd, &conn_ctx, &reqs,
-	                                error_records);
+	                                error_record);
 	if (G_UNLIKELY(rc != 0)) return rc;
 
 	g_timer_start(conn_ctx->last_access);
 
-	rc = post_server_reads(context, conn_ctx, error_records);
+	rc = post_server_reads(context, conn_ctx, error_record);
 	if (G_UNLIKELY(rc != 0)) return rc;
 
 	while (reqs != NULL) {
@@ -887,14 +906,14 @@ on_read_completion(struct spectrum_reader_context_ *context, unsigned pfd,
 	}
 
 	if (!conn_ctx->established && conn_ctx->num_posted_wr == 0)
-		rc = complete_server_disconnect(context, conn_ctx, error_records);
+		rc = complete_server_disconnect(context, conn_ctx, error_record);
 
 	return rc;
 }
 
 static int
 on_inactivity_timer_event(struct spectrum_reader_context_ *context,
-                          GSList **error_records)
+                          struct vys_error_record **error_record)
 {
 	struct pollfd *pollfd = &g_array_index(
 		context->pollfds, struct pollfd, INACTIVITY_TIMER_FD_INDEX);
@@ -910,18 +929,19 @@ on_inactivity_timer_event(struct spectrum_reader_context_ *context,
 	                         void *unused1) {
 		if (g_timer_elapsed(conn_ctx->last_access, NULL)
 		    >= inactive_server_timeout_sec)
-			begin_server_disconnect(context, conn_ctx, error_records);
+			begin_server_disconnect(context, conn_ctx, error_record);
 	}
 
 	g_hash_table_foreach(
 		context->connections, (GHFunc)disconnect_inactive, NULL);
 
-	if (*error_records != NULL) return -1;
+	if (*error_record != NULL) return -1;
 	return 0;
 }
 
 static int
-on_poll_events(struct spectrum_reader_context_ *context, GSList **error_records)
+on_poll_events(struct spectrum_reader_context_ *context,
+               struct vys_error_record **error_record)
 {
 	int rc = 0;
 
@@ -929,9 +949,9 @@ on_poll_events(struct spectrum_reader_context_ *context, GSList **error_records)
 	struct pollfd *cm_pollfd =
 		&g_array_index(context->pollfds, struct pollfd, CM_EVENT_FD_INDEX);
 	if (cm_pollfd->revents & POLLIN) {
-		rc = on_cm_event(context, error_records);
+		rc = on_cm_event(context, error_record);
 	} else if (cm_pollfd->revents & (POLLERR | POLLHUP)) {
-		MSG_ERROR(error_records, -1, "%s",
+		MSG_ERROR(error_record, -1, "%s",
 		          "rdma cm event channel ERR or HUP");
 		rc = -1;
 	}
@@ -940,7 +960,7 @@ on_poll_events(struct spectrum_reader_context_ *context, GSList **error_records)
 	struct pollfd *tm_pollfd = &g_array_index(context->pollfds, struct pollfd,
 	                                          INACTIVITY_TIMER_FD_INDEX);
 	if (tm_pollfd->revents & POLLIN)
-		rc = on_inactivity_timer_event(context, error_records);
+		rc = on_inactivity_timer_event(context, error_record);
 
 	/* read completion events */
 	for (unsigned i = NUM_FIXED_FDS; i < context->pollfds->len; ++i) {
@@ -948,9 +968,9 @@ on_poll_events(struct spectrum_reader_context_ *context, GSList **error_records)
 			&g_array_index(context->pollfds, struct pollfd, i);
 		int rc1;
 		if (ev_pollfd->revents & POLLIN) {
-			rc1 = on_read_completion(context, i, error_records);
+			rc1 = on_read_completion(context, i, error_record);
 		} else if (ev_pollfd->revents & (POLLERR | POLLHUP)) {
-			MSG_ERROR(error_records, -1, "%s",
+			MSG_ERROR(error_record, -1, "%s",
 			          "connection event channel ERR or HUP");
 			rc1 = -1;
 		}
@@ -967,7 +987,8 @@ on_poll_events(struct spectrum_reader_context_ *context, GSList **error_records)
 
 static int
 to_quit_state(struct spectrum_reader_context_ *context,
-              struct data_path_message *quit_msg, GSList **error_records)
+              struct data_path_message *quit_msg,
+              struct vys_error_record **error_record)
 {
 	g_assert(context->state != STATE_DONE);
 
@@ -978,7 +999,7 @@ to_quit_state(struct spectrum_reader_context_ *context,
 				g_sequence_get_begin_iter(context->fd_connections);
 			while (!g_sequence_iter_is_end(iter)) {
 				struct server_connection_context *conn_ctx = g_sequence_get(iter);
-				begin_server_disconnect(context, conn_ctx, error_records);
+				begin_server_disconnect(context, conn_ctx, error_record);
 				iter = g_sequence_iter_next(iter);
 			}
 		}
@@ -987,7 +1008,7 @@ to_quit_state(struct spectrum_reader_context_ *context,
 				data_path_message_new(context->shared->signal_msg_num_spectra);
 			quit_msg->typ = DATA_PATH_QUIT;
 		}
-		rc = loopback_msg(context, quit_msg, error_records);
+		rc = loopback_msg(context, quit_msg, error_record);
 		context->state = STATE_QUIT;
 		context->quit_msg = quit_msg;
 	}
@@ -996,7 +1017,7 @@ to_quit_state(struct spectrum_reader_context_ *context,
 
 static int
 spectrum_reader_loop(struct spectrum_reader_context_ *context,
-                     GSList **error_records)
+                     struct vys_error_record **error_record)
 {
 	int result = 0;
 	bool quit = false;
@@ -1005,9 +1026,9 @@ spectrum_reader_loop(struct spectrum_reader_context_ *context,
 		int nfd = poll((struct pollfd *)(context->pollfds->data),
 		               context->pollfds->len, 0);
 		if (G_LIKELY(nfd > 0)) {
-			rc = on_poll_events(context, error_records);
+			rc = on_poll_events(context, error_record);
 		} else if (G_UNLIKELY(nfd < 0 && errno != EINTR)) {
-			MSG_ERROR(error_records, errno,
+			MSG_ERROR(error_record, errno,
 			          "spectrum_reader poll failed: %s", strerror(errno));
 			rc = -1;
 		}
@@ -1015,9 +1036,9 @@ spectrum_reader_loop(struct spectrum_reader_context_ *context,
 		struct data_path_message *msg =
 			g_async_queue_try_pop(context->shared->read_request_queue);
 		if (msg != NULL)
-			rc1 = on_data_path_message(context, msg, error_records);
+			rc1 = on_data_path_message(context, msg, error_record);
 		if (G_UNLIKELY(rc != 0 || rc1 != 0)) {
-			to_quit_state(context, NULL, error_records);
+			to_quit_state(context, NULL, error_record);
 			result = -1;
 		}
 		quit = (context->state == STATE_DONE
@@ -1029,7 +1050,7 @@ spectrum_reader_loop(struct spectrum_reader_context_ *context,
 
 static int
 start_inactivity_timer(struct spectrum_reader_context_ *context,
-                       GSList **error_records)
+                       struct vys_error_record **error_record)
 {
 	struct pollfd *tm_pollfd = &g_array_index(context->pollfds, struct pollfd,
 	                                          INACTIVITY_TIMER_FD_INDEX);
@@ -1045,14 +1066,14 @@ start_inactivity_timer(struct spectrum_reader_context_ *context,
 		};
 		int rc = timerfd_settime(tm_pollfd->fd, 0, &itimerspec, NULL);
 		if (rc < 0) {
-			MSG_ERROR(error_records, errno,
+			MSG_ERROR(error_record, errno,
 			          "Failed to start inactivity timer: %s",
 			          strerror(errno));
-			stop_inactivity_timer(context, error_records);
+			stop_inactivity_timer(context, error_record);
 			return rc;
 		}
 	} else {
-		MSG_ERROR(error_records, errno, "Failed to create inactivity timer: %s",
+		MSG_ERROR(error_record, errno, "Failed to create inactivity timer: %s",
 		          strerror(errno));
 	}
 	return tm_pollfd->fd;
@@ -1060,7 +1081,7 @@ start_inactivity_timer(struct spectrum_reader_context_ *context,
 
 static int
 stop_inactivity_timer(struct spectrum_reader_context_ *context,
-                      GSList **error_records)
+                      struct vys_error_record **error_record)
 {
 	struct pollfd *tm_pollfd = &g_array_index(context->pollfds, struct pollfd,
 	                                          INACTIVITY_TIMER_FD_INDEX);
@@ -1068,7 +1089,7 @@ stop_inactivity_timer(struct spectrum_reader_context_ *context,
 	if (tm_pollfd->fd >= 0) {
 		rc = close(tm_pollfd->fd);
 		if (rc < 0)
-			MSG_ERROR(error_records, errno,
+			MSG_ERROR(error_record, errno,
 			          "Failed to close inactivity timer: %s", strerror(errno));
 	}
 	return rc;
@@ -1076,7 +1097,8 @@ stop_inactivity_timer(struct spectrum_reader_context_ *context,
 
 static int
 loopback_msg(struct spectrum_reader_context_ *context,
-             struct data_path_message *msg, GSList **error_records)
+             struct data_path_message *msg,
+             struct vys_error_record **error_record)
 {
 	int result = 0;
 	ssize_t num_written = 0;
@@ -1086,7 +1108,7 @@ loopback_msg(struct spectrum_reader_context_ *context,
 		if (G_LIKELY(n >= 0)) {
 			num_written += n;
 		} else if (errno != EINTR && n < 0) {
-			MSG_ERROR(error_records, errno, "Failed to write to loop pipe: %s",
+			MSG_ERROR(error_record, errno, "Failed to write to loop pipe: %s",
 			          strerror(errno));
 			result = -1;
 		}
@@ -1098,7 +1120,7 @@ loopback_msg(struct spectrum_reader_context_ *context,
 void *
 spectrum_reader(struct spectrum_reader_context *shared)
 {
-	GSList *error_records = NULL;
+	struct vys_error_record *error_record = NULL;
 
 	struct spectrum_reader_context_ context;
 	memset(&context, 0, sizeof(context));
@@ -1116,57 +1138,57 @@ spectrum_reader(struct spectrum_reader_context *shared)
 		pollfd->events = 0;
 	}
 
-	int rc = start_rdma_cm(&context, &error_records);
+	int rc = start_rdma_cm(&context, &error_record);
 	if (rc < 0)
 		goto cleanup_and_return;
 
-	rc = start_inactivity_timer(&context, &error_records);
+	rc = start_inactivity_timer(&context, &error_record);
 	if (rc < 0)
 		goto cleanup_and_return;
 
 	READY(&shared->handle->gate);
 
 	context.state = STATE_RUN;
-	rc = spectrum_reader_loop(&context, &error_records);
+	rc = spectrum_reader_loop(&context, &error_record);
 
  cleanup_and_return:
 	READY(&shared->handle->gate);
 
 	/* initialization failures may result in not being in STATE_DONE state */
 	if (context.state != STATE_DONE) {
-		to_quit_state(&context, NULL, &error_records);
+		to_quit_state(&context, NULL, &error_record);
 		/* polling loop will only poll the loop fd, as the others are now
 		 * closed */
-		spectrum_reader_loop(&context, &error_records);
+		spectrum_reader_loop(&context, &error_record);
 	}
 
-	stop_inactivity_timer(&context, &error_records);
+	stop_inactivity_timer(&context, &error_record);
 
-	stop_rdma_cm(&context, &error_records);
+	stop_rdma_cm(&context, &error_record);
 
 	rc = close(shared->loop_fd);
 	if (rc != 0)
-		MSG_ERROR(&error_records, errno, "Failed to close loop fd: %s",
+		MSG_ERROR(&error_record, errno, "Failed to close loop fd: %s",
 		          strerror(errno));
 
 	g_assert(context.end_msg != NULL && context.end_msg->typ == DATA_PATH_END);
-	context.end_msg->error_records =
-		g_slist_concat(error_records, context.end_msg->error_records);
+	context.end_msg->error_record =
+		vys_error_record_concat(error_record, context.end_msg->error_record);
 
 	/* create vysmaw_message for end result */
 	struct vysmaw_result result;
-	if (context.end_msg->error_records == NULL) {
+	if (context.end_msg->error_record == NULL) {
 		result.code = VYSMAW_NO_ERROR;
 		result.syserr_desc = NULL;
 	} else {
 		result.code = VYSMAW_SYSERR;
+		context.end_msg->error_record =
+			vys_error_record_reverse(context.end_msg->error_record);
 		GString *str = g_string_new("");
-		GSList *er = context.end_msg->error_records;
+		struct vys_error_record *er = context.end_msg->error_record;
 		while (er != NULL) {
-			g_string_append_printf(str,
-			                       "%s\n",
-			                       ((struct error_record *)(er->data))->desc);
-			er = g_slist_next(er);
+			g_string_append_printf(str, "%s\n", er->desc);
+			er = er->next;
 		}
 		result.syserr_desc = g_string_free(str, FALSE);
 	}

--- a/src/spectrum_reader.c
+++ b/src/spectrum_reader.c
@@ -1182,15 +1182,8 @@ spectrum_reader(struct spectrum_reader_context *shared)
 		result.syserr_desc = NULL;
 	} else {
 		result.code = VYSMAW_SYSERR;
-		context.end_msg->error_record =
-			vys_error_record_reverse(context.end_msg->error_record);
-		GString *str = g_string_new("");
-		struct vys_error_record *er = context.end_msg->error_record;
-		while (er != NULL) {
-			g_string_append_printf(str, "%s\n", er->desc);
-			er = er->next;
-		}
-		result.syserr_desc = g_string_free(str, FALSE);
+		result.syserr_desc =
+			vys_error_record_to_string(&(context.end_msg->error_record));
 	}
 	struct vysmaw_message *msg = end_message_new(shared->handle, &result);
 

--- a/src/vys.c
+++ b/src/vys.c
@@ -15,56 +15,12 @@
 // You should have received a copy of the GNU General Public License along with
 // vysmaw.  If not, see <http://www.gnu.org/licenses/>.
 //
-#include <vys.h>
+#include <vys_private.h>
 #include <glib.h>
-#include <stdio.h>
-#include <string.h>
 
-#define SIGNAL_MULTICAST_ADDRESS_KEY "signal_multicast_address"
-
-static gchar *load_config(
-	const gchar *path, struct vys_error_record **error_record)
-	__attribute__((malloc,returns_nonnull));
-static gchar *default_config()
-	__attribute__((returns_nonnull,malloc));
 void init_from_key_file(
 	GKeyFile *kf, struct vys_configuration *config)
 	__attribute__((nonnull));
-
-static gchar *
-load_config(const gchar *path, struct vys_error_record **error_record)
-{
-	gchar *result = NULL;
-	if (path != NULL) {
-		GKeyFile *kf = g_key_file_new();
-		GError *err = NULL;
-		if (g_key_file_load_from_file(kf, path, G_KEY_FILE_NONE, &err)) {
-			result = g_key_file_to_data(kf, NULL, NULL);
-		} else {
-			if (error_record != NULL)
-				MSG_ERROR(error_record, -1,
-				          "Failed to load configuration file '%s': %s",
-				          path, err->message);
-			g_error_free(err);
-		}
-		g_key_file_free(kf);
-	}
-	if (result == NULL)
-		result = g_strdup("");
-	return result;
-}
-
-static gchar *
-default_config()
-{
-	GKeyFile *kf = g_key_file_new();
-	g_key_file_set_string(kf, VYS_CONFIG_GROUP_NAME,
-	                      SIGNAL_MULTICAST_ADDRESS_KEY,
-	                      VYS_SIGNAL_MULTICAST_ADDRESS);
-	gchar *result = g_key_file_to_data(kf, NULL, NULL);
-	g_key_file_free(kf);
-	return result;
-}
 
 void
 init_from_key_file(GKeyFile *kf, struct vys_configuration *config)
@@ -86,11 +42,10 @@ struct vys_configuration *
 vys_configuration_new(const char *path)
 {
 	struct vys_configuration *result = g_new0(struct vys_configuration, 1);
-	gchar *dcfg = default_config();
-	gchar *fcfg = load_config(VYS_CONFIG_PATH, NULL);
+	gchar *base = config_vys_base();
 	gchar *pcfg = load_config(path, &(result->error_record));
 	if (result->error_record == NULL) {
-		gchar *cfg = g_strjoin("\n", dcfg, fcfg, pcfg, NULL);
+		gchar *cfg = g_strjoin("\n", base, pcfg, NULL);
 		GKeyFile *kf = g_key_file_new();
 		if (g_key_file_load_from_data(kf, cfg, -1, G_KEY_FILE_NONE, NULL)) {
 			init_from_key_file(kf, result);
@@ -101,6 +56,8 @@ vys_configuration_new(const char *path)
 		g_key_file_free(kf);
 		g_free(cfg);
 	}
+	g_free(base);
+	g_free(pcfg);
 	return result;
 }
 

--- a/src/vys.c
+++ b/src/vys.c
@@ -118,3 +118,16 @@ vys_error_record_concat(struct vys_error_record *first,
 	}
 	return result;
 }
+
+char *
+vys_error_record_to_string(struct vys_error_record **record)
+{
+	*record = vys_error_record_reverse(*record);
+	GString *str = g_string_new("");
+	struct vys_error_record *er = *record;
+	while (er != NULL) {
+		g_string_append_printf(str, "%s\n", er->desc);
+		er = er->next;
+	}
+	return g_string_free(str, FALSE);
+}

--- a/src/vys.c
+++ b/src/vys.c
@@ -1,0 +1,78 @@
+//
+// Copyright © 2016 Associated Universities, Inc. Washington DC, USA.
+//
+// This file is part of vysmaw.
+//
+// vysmaw is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// vysmaw is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// vysmaw.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <vys.h>
+#include <glib.h>
+#include <stdio.h>
+#include <string.h>
+
+static gboolean
+load_config(GKeyFile *keyfile, const gchar *path)
+{
+	GError *error = NULL;
+	gboolean result =
+		g_key_file_load_from_file(keyfile, path, G_KEY_FILE_NONE, &error);
+	if (!result) {
+		fprintf(stderr, "Failed to load vys config file '%s': %s\n",
+		        path, error->message);
+		g_error_free(error);
+	}
+	return result;
+}
+
+struct vys_configuration *
+vys_configuration_new(const char *path)
+{
+	struct vys_configuration *result = g_new(struct vys_configuration, 1);
+	/* initialize with defaults */
+	g_strlcpy(result->signal_multicast_address,
+	          VYS_SIGNAL_MULTICAST_ADDRESS,
+	          sizeof(result->signal_multicast_address));
+
+	/* Override defaults with values from configuration file.*/
+	GKeyFile *keyfile = g_key_file_new();
+	if (load_config(keyfile, (path != NULL) ? path : VYS_CONFIG_PATH)) {
+		/* get values from config file */
+		GError *error = NULL;
+		/* signal_multicast_address */
+		gchar *mc_addr = g_key_file_get_string(
+			keyfile, VYS_CONFIG_GROUP_NAME, "signal_multicast_address", &error);
+		if (mc_addr != NULL) {
+			/* check that value from file is not too long */
+			if (strlen(mc_addr) < sizeof(result->signal_multicast_address))
+				g_strlcpy(result->signal_multicast_address, mc_addr,
+				          sizeof(result->signal_multicast_address));
+			else
+				fprintf(stderr, "%s",
+				        "Configuration value too long - using default value\n");
+			g_free(mc_addr);
+		} else {
+			fprintf(stderr,
+			        "Failed to read configuration parameter: %s - "
+			        "using default value\n",
+			        error->message);
+			g_error_free(error);
+		}
+	}
+	return result;
+}
+
+void
+vys_configuration_free(struct vys_configuration *config)
+{
+	g_free(config);
+}

--- a/src/vys.conf
+++ b/src/vys.conf
@@ -1,0 +1,3 @@
+[system]
+
+signal_multicast_address = 224.0.0.100

--- a/src/vys.conf
+++ b/src/vys.conf
@@ -1,3 +1,3 @@
-[system]
+[vys]
 
 signal_multicast_address = 224.0.0.100

--- a/src/vys.conf
+++ b/src/vys.conf
@@ -1,3 +1,5 @@
 [vys]
 
+# multicast address for signal messages containing available spectrum metadata;
+# expected format is dotted quad IP address string
 signal_multicast_address = 224.0.0.100

--- a/src/vys.h
+++ b/src/vys.h
@@ -32,7 +32,7 @@ struct vys_configuration {
 };
 
 extern struct vys_configuration *vys_configuration_new(const char *path)
-	__attribute__((returns_nonnull,malloc));
+	__attribute__((malloc));
 extern void vys_configuration_free(struct vys_configuration *config)
 	__attribute__((nonnull));
 

--- a/src/vys.h
+++ b/src/vys.h
@@ -59,6 +59,10 @@ extern struct vys_error_record *vys_error_record_reverse(
 	struct vys_error_record *record);
 extern struct vys_error_record *vys_error_record_concat(
 	struct vys_error_record *first, struct vys_error_record *second);
+extern char *vys_error_record_to_string(
+	struct vys_error_record **record)
+	__attribute__((malloc,returns_nonnull,nonnull));
+
 
 #define MSG_ERROR(records, err, format, ...)                            \
 	{ *(records) = \

--- a/src/vys.h
+++ b/src/vys.h
@@ -57,6 +57,11 @@ extern struct vys_error_record *vys_error_record_reverse(
 extern struct vys_error_record *vys_error_record_concat(
 	struct vys_error_record *first, struct vys_error_record *second);
 
+#define MSG_ERROR(records, err, format, ...)                            \
+	{ *(records) = \
+			vys_error_record_desc_dup_printf( \
+				*(records), (err), G_STRLOC ": " format, ##__VA_ARGS__); }
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/vys.h
+++ b/src/vys.h
@@ -31,10 +31,31 @@ struct vys_configuration {
 	char signal_multicast_address[VYS_MULTICAST_ADDRESS_SIZE];
 };
 
+struct vys_error_record {
+	int errnum;
+	char *desc;
+	struct vys_error_record *next;
+};
+
 extern struct vys_configuration *vys_configuration_new(const char *path)
 	__attribute__((malloc));
 extern void vys_configuration_free(struct vys_configuration *config)
 	__attribute__((nonnull));
+
+extern struct vys_error_record *vys_error_record_new(
+	struct vys_error_record *tail, int errnum, char *desc)
+	__attribute__((nonnull(3),returns_nonnull,malloc));
+extern struct vys_error_record *vys_error_record_desc_dup(
+	struct vys_error_record *tail, int errnum, const char *desc)
+	__attribute__((nonnull(3),returns_nonnull,malloc));
+extern struct vys_error_record *vys_error_record_desc_dup_printf(
+	struct vys_error_record *tail, int errnum, const char *format, ...)
+	__attribute__((nonnull(3),returns_nonnull,malloc,format(printf,3,4)));
+extern void vys_error_record_free(struct vys_error_record *record);
+extern struct vys_error_record *vys_error_record_reverse(
+	struct vys_error_record *record);
+extern struct vys_error_record *vys_error_record_concat(
+	struct vys_error_record *first, struct vys_error_record *second);
 
 #ifdef __cplusplus
 }

--- a/src/vys.h
+++ b/src/vys.h
@@ -25,20 +25,23 @@ extern "C" {
 #define VYS_MULTICAST_ADDRESS_SIZE 32
 #define VYS_DATA_DIGEST_SIZE 16
 
-struct vys_configuration {
-	/* multicast address for signal messages; expected format is dotted quad IP
-	 * address string */
-	char signal_multicast_address[VYS_MULTICAST_ADDRESS_SIZE];
-};
-
 struct vys_error_record {
 	int errnum;
 	char *desc;
 	struct vys_error_record *next;
 };
 
-extern struct vys_configuration *vys_configuration_new(const char *path)
-	__attribute__((malloc));
+struct vys_configuration {
+	struct vys_error_record *error_record;
+
+	/* multicast address for signal messages; expected format is dotted quad IP
+	 * address string */
+	char signal_multicast_address[VYS_MULTICAST_ADDRESS_SIZE];
+};
+
+extern struct vys_configuration *vys_configuration_new(
+	const char *path)
+	__attribute__((malloc,returns_nonnull));
 extern void vys_configuration_free(struct vys_configuration *config)
 	__attribute__((nonnull));
 

--- a/src/vys.h
+++ b/src/vys.h
@@ -1,0 +1,43 @@
+//
+// Copyright © 2016 Associated Universities, Inc. Washington DC, USA.
+//
+// This file is part of vysmaw.
+//
+// vysmaw is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// vysmaw is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// vysmaw.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef VYS_H_
+#define VYS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VYS_MULTICAST_ADDRESS_SIZE 32
+#define VYS_DATA_DIGEST_SIZE 16
+
+struct vys_configuration {
+	/* multicast address for signal messages; expected format is dotted quad IP
+	 * address string */
+	char signal_multicast_address[VYS_MULTICAST_ADDRESS_SIZE];
+};
+
+extern struct vys_configuration *vys_configuration_new(const char *path)
+	__attribute__((returns_nonnull,malloc));
+extern void vys_configuration_free(struct vys_configuration *config)
+	__attribute__((nonnull));
+
+#ifdef __cplusplus
+}
+#endif
+	
+#endif /* VYS_H_ */

--- a/src/vys_private.c
+++ b/src/vys_private.c
@@ -66,3 +66,29 @@ config_vys_base(void)
 	g_free(dcfg);
 	return result;
 }
+
+void
+init_from_key_file_vys(GKeyFile *kf, struct vys_configuration *config)
+{
+	GError *err = NULL;
+	gchar *mc_addr = g_key_file_get_string(
+		kf, VYS_CONFIG_GROUP_NAME, SIGNAL_MULTICAST_ADDRESS_KEY, &err);
+	if (err == NULL) {
+		g_assert(mc_addr != NULL);
+		gsize mc_addr_len =
+			g_strlcpy(config->signal_multicast_address, mc_addr,
+			          sizeof(config->signal_multicast_address));
+		g_free(mc_addr);
+		/* check that value is not too long */
+		if (mc_addr_len >= sizeof(config->signal_multicast_address))
+			MSG_ERROR(&(config->error_record), -1,
+			          "'%s' field value is too long",
+			          SIGNAL_MULTICAST_ADDRESS_KEY);
+	} else {
+		MSG_ERROR(&(config->error_record), -1,
+		          "Failed to parse '%s' field: %s",
+		          SIGNAL_MULTICAST_ADDRESS_KEY,
+		          err->message);
+		g_error_free(err);
+	}
+}

--- a/src/vys_private.c
+++ b/src/vys_private.c
@@ -1,0 +1,68 @@
+//
+// Copyright © 2016 Associated Universities, Inc. Washington DC, USA.
+//
+// This file is part of vysmaw.
+//
+// vysmaw is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// vysmaw is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// vysmaw.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <vys_private.h>
+#include <glib.h>
+
+static gchar *default_config_vys()
+	__attribute__((returns_nonnull,malloc));
+
+static gchar *
+default_config_vys()
+{
+	GKeyFile *kf = g_key_file_new();
+	g_key_file_set_string(kf, VYS_CONFIG_GROUP_NAME,
+	                      SIGNAL_MULTICAST_ADDRESS_KEY,
+	                      VYS_SIGNAL_MULTICAST_ADDRESS);
+	gchar *result = g_key_file_to_data(kf, NULL, NULL);
+	g_key_file_free(kf);
+	return result;
+}
+
+char *
+load_config(const char *path, struct vys_error_record **error_record)
+{
+	gchar *result = NULL;
+	if (path != NULL) {
+		GKeyFile *kf = g_key_file_new();
+		GError *err = NULL;
+		if (g_key_file_load_from_file(kf, path, G_KEY_FILE_NONE, &err)) {
+			result = g_key_file_to_data(kf, NULL, NULL);
+		} else {
+			if (error_record != NULL)
+				MSG_ERROR(error_record, -1,
+				          "Failed to load configuration file '%s': %s",
+				          path, err->message);
+			g_error_free(err);
+		}
+		g_key_file_free(kf);
+	}
+	if (result == NULL)
+		result = g_strdup("");
+	return result;
+}
+
+char *
+config_vys_base(void)
+{
+	char *dcfg = default_config_vys();
+	char *fcfg = load_config(VYS_CONFIG_PATH, NULL);
+	char *result = g_strjoin("\n", dcfg, fcfg, NULL);
+	g_free(fcfg);
+	g_free(dcfg);
+	return result;
+}

--- a/src/vys_private.h
+++ b/src/vys_private.h
@@ -19,6 +19,7 @@
 #define VYS_PRIVATE_H_
 
 #include <vys.h>
+#include <glib.h>
 
 /* vys configuration file keys */
 #define VYS_CONFIG_GROUP_NAME "vys"
@@ -29,5 +30,8 @@ extern char *config_vys_base(void)
 extern char *load_config(
 	const char *path, struct vys_error_record **error_record)
 	__attribute__((malloc,returns_nonnull));
+extern void init_from_key_file_vys(
+	GKeyFile *kf, struct vys_configuration *config)
+	__attribute__((nonnull));
 
 #endif /* VYS_PRIVATE_H_ */

--- a/src/vys_private.h
+++ b/src/vys_private.h
@@ -20,6 +20,8 @@
 
 #include <vys.h>
 
+/* vys configuration file keys */
+#define VYS_CONFIG_GROUP_NAME "vys"
 #define SIGNAL_MULTICAST_ADDRESS_KEY "signal_multicast_address"
 
 extern char *config_vys_base(void)

--- a/src/vys_private.h
+++ b/src/vys_private.h
@@ -1,0 +1,31 @@
+//
+// Copyright © 2016 Associated Universities, Inc. Washington DC, USA.
+//
+// This file is part of vysmaw.
+//
+// vysmaw is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// vysmaw is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// vysmaw.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef VYS_PRIVATE_H_
+#define VYS_PRIVATE_H_
+
+#include <vys.h>
+
+#define SIGNAL_MULTICAST_ADDRESS_KEY "signal_multicast_address"
+
+extern char *config_vys_base(void)
+	__attribute__((malloc,returns_nonnull));
+extern char *load_config(
+	const char *path, struct vys_error_record **error_record)
+	__attribute__((malloc,returns_nonnull));
+
+#endif /* VYS_PRIVATE_H_ */

--- a/src/vysmaw.c
+++ b/src/vysmaw.c
@@ -161,7 +161,7 @@ vysmaw_shutdown(vysmaw_handle handle)
 }
 
 struct vysmaw_configuration *
-vysmaw_configuration_new(void)
+vysmaw_configuration_new(const char *path)
 {
 	struct vysmaw_configuration *result =
 		g_try_new(struct vysmaw_configuration, 1);

--- a/src/vysmaw.c
+++ b/src/vysmaw.c
@@ -194,5 +194,6 @@ vysmaw_configuration_new(void)
 void
 vysmaw_configuration_free(struct vysmaw_configuration *config)
 {
+	vys_error_record_free(config->error_record);
 	g_free(config);
 }

--- a/src/vysmaw.c
+++ b/src/vysmaw.c
@@ -94,21 +94,23 @@ vysmaw_start(const struct vysmaw_configuration *config,
 	result->in_shutdown = false;
 	result->result = NULL;
 	memcpy((void *)&result->config, config, sizeof(*config));
-	if (config->single_spectrum_buffer_pool) {
-		size_t num_buffers =
-			config->spectrum_buffer_pool_size
-			/ config->max_spectrum_buffer_size;
-		result->pool = spectrum_buffer_pool_new(
-			config->max_spectrum_buffer_size, num_buffers);
-		result->new_valid_buffer_fn = new_valid_buffer_from_pool;
-		result->lookup_buffer_pool_fn = lookup_buffer_pool_from_pool;
-		result->list_buffer_pools_fn = buffer_pool_list_from_pool;
-	} else {
-		MUTEX_INIT(result->pool_collection_mtx);
-		result->pool_collection = spectrum_buffer_pool_collection_new();
-		result->new_valid_buffer_fn = new_valid_buffer_from_collection;
-		result->lookup_buffer_pool_fn = lookup_buffer_pool_from_collection;
-		result->list_buffer_pools_fn = buffer_pool_list_from_collection;
+	if (result->config.error_record == NULL) {
+		if (config->single_spectrum_buffer_pool) {
+			size_t num_buffers =
+				config->spectrum_buffer_pool_size
+				/ config->max_spectrum_buffer_size;
+			result->pool = spectrum_buffer_pool_new(
+				config->max_spectrum_buffer_size, num_buffers);
+			result->new_valid_buffer_fn = new_valid_buffer_from_pool;
+			result->lookup_buffer_pool_fn = lookup_buffer_pool_from_pool;
+			result->list_buffer_pools_fn = buffer_pool_list_from_pool;
+		} else {
+			MUTEX_INIT(result->pool_collection_mtx);
+			result->pool_collection = spectrum_buffer_pool_collection_new();
+			result->new_valid_buffer_fn = new_valid_buffer_from_collection;
+			result->lookup_buffer_pool_fn = lookup_buffer_pool_from_collection;
+			result->list_buffer_pools_fn = buffer_pool_list_from_collection;
+		}
 	}
 
 	/* per consumer initialization */
@@ -122,13 +124,21 @@ vysmaw_start(const struct vysmaw_configuration *config,
 	result->num_consumers = num_consumers;
 	result->consumers = (struct consumer *)g_array_free(priv_consumers, false);
 
-	/* service threads initialization */
-	MUTEX_INIT(result->gate.mtx);
-	COND_INIT(result->gate.cond);
-	int rc = init_service_threads(result);
-	if (rc != 0) {
-		handle_unref(result);
-		result = NULL;
+	if (result->config.error_record == NULL) {
+		/* service threads initialization */
+		MUTEX_INIT(result->gate.mtx);
+		COND_INIT(result->gate.cond);
+		init_service_threads(result);
+	}
+	if (result->config.error_record != NULL) {
+		result->in_shutdown = true;
+		struct vysmaw_result rc = {
+			.code = VYSMAW_SYSERR,
+			.syserr_desc = vys_error_record_to_string(
+				(struct vys_error_record **)&(result->config.error_record))
+		};
+		struct vysmaw_message *msg = end_message_new(result, &rc);
+		post_msg(result, msg);
 	}
 	return result;
 }

--- a/src/vysmaw.conf
+++ b/src/vysmaw.conf
@@ -1,0 +1,98 @@
+[vysmaw]
+
+# Size of memory region for storing spectra retrieved via RDMA from the CBE. The
+# memory region is allocated and registered for RDMA by the library. Memory
+# registration affects memory management on the host, as it pins physical memory
+# in the virtual address space -- too large an allocation may be detrimental to
+# the application; too little, and the library may be unable to copy the data
+# from the CBE when it becomes available, resulting in lost data. Note that one
+# memory region of the given size will be allocated for every size of spectrum
+# that is received by the client unless 'single_spectrum_buffer_pool' is true.
+spectrum_buffer_pool_size = 10485760
+
+# Maintain a single pool containing buffers sized to accommodate the expected
+# size of a spectrum.
+single_spectrum_buffer_pool = true
+
+# The maximum expected size in bytes of a single spectrum that the client will
+# receive. Note that all spectra that exceed this size will not be sent to the
+# client, regardless of the result of the client filter predicate. This value is
+# ignored unless 'single_spectrum_buffer_pool' is true.
+max_spectrum_buffer_size = 1048576
+
+# Size of memory region for storing signal messages carrying spectrum metadata
+# sent from all active CBE nodes. The memory region is allocated and registered
+# for InfiniBand messaging by the library. Setting the value too low will cause
+# the receiver to miss signal messages. Keep in mind that every client should be
+# prepared to receive _all_ such signal messages sent from every CBE node.
+signal_message_pool_size = 10485760
+
+# vysmaw clients can either connect to a (CBE) sending process (to read spectral
+# data) immediately upon receipt of any signal message from that process, or
+# wait until a signal message is received from the process which matches (one
+# of) the client's spectrum filter(s). When 'eager_connect' is 'false', the
+# connection occurs only after a spectrum filter match; set value to 'true' for
+# the other behavior.
+eager_connect = true
+
+# When 'eager_connect' is true, the following sets the minimum time between
+# attempts to connect to each sending process eagerly. (A value less than 0.1
+# sec is ignored.
+eager_connect_idle_sec = 1.0
+
+# Control disposition of client read requests (for spectral data) after
+# initiating a connection request to a sending process, but prior to that
+# connection becoming ready. A value of 'true' maintains read requests that
+# arrive in such intervals in a queue for processing until after the connection
+# is ready; a value of 'false' will ignore those requests. Note that for fast
+# data streams resulting in many client read requests, the backlog can
+# accumulate very quickly, and will take some time to resolve.
+preconnect_backlog = true
+
+# Maximum depth of message queue.
+max_depth_message_queue = 1000
+
+# Overhead needed to resume data flow after message queue overflow.  Operational
+# value will be limited to < max_depth_message_queue.
+queue_resume_overhead = 100
+
+# Maximum number of buffer starvation events to wait before sending a
+# VYSMAW_MESSAGE_[DATA|SIGNAL]_BUFFER_STARVATION message.
+#
+# TODO: distinguish latency for data and signal buffers?
+max_starvation_latency = 100
+
+#
+# The following are probably best left at their default values, but expert users
+# may find them useful.
+#
+
+# timeout, in milliseconds, to resolve InfiniBand/RDMA route
+resolve_route_timeout_ms = 1000
+
+# timeout, in milliseconds, to resolve InfiniBand/RDMA address
+resolve_addr_timeout_ms = 1000
+
+# timeout, in seconds, to determine data server inactivity
+inactive_server_timeout_sec = 43200
+
+# interval to check for shutdown, in milliseconds
+shutdown_check_interval_ms = 1000
+
+# maximum number of posted (uncompleted) signal receive requests (may be
+# automatically reduced by hardware and/or system limitations)
+signal_receive_max_posted = 10000
+
+# signal receive completions to acknowledge at a time, expressed as a part of
+# the maximum number of posted work requests: minimum number acknowledged will
+# be signal_receive_max_posted / signal_receive_min_ack_part
+signal_receive_min_ack_part = 10
+
+# maximum number of posted (uncompleted) rdma read requests (may be
+# automatically reduced by hardware and/or system limitations)
+rdma_read_max_posted = 1000
+
+# rdma read request completions to acknowledge at a time, expressed as a part of
+# the maximum number of posted work requests: minimum number acknowledged will
+# be rdma_read_max_posted / rdma_read_min_ack_part
+rdma_read_min_ack_part = 10

--- a/src/vysmaw.h
+++ b/src/vysmaw.h
@@ -379,11 +379,13 @@ extern struct vysmaw_message *vysmaw_message_queue_try_pop(
 	vysmaw_message_queue queue)
 	__attribute__((nonnull));
 
-/* Get a configuration instance, filled with default values.
+/* Get a configuration instance, filled with default values. Optionally provide
+ * a path to a vysmaw configuration file.
  *
  * @see vysmaw_configuration_free()
  */
-extern struct vysmaw_configuration *vysmaw_configuration_new(void)
+extern struct vysmaw_configuration *vysmaw_configuration_new(
+	const char *path)
 	__attribute__((malloc,returns_nonnull));
 
 /* Free a configuration instance that was allocated using

--- a/src/vysmaw.h
+++ b/src/vysmaw.h
@@ -30,6 +30,8 @@ extern "C" {
 #define VYSMAW_DATA_DIGEST_SIZE 16
 
 struct vysmaw_configuration {
+	struct vys_error_record *error_record;
+
 	/* multicast address for signal messages from CBE containing available
 	 * spectrum metadata; expected format is dotted quad IP address string */
 	char signal_multicast_address[VYSMAW_MULTICAST_ADDRESS_SIZE];

--- a/src/vysmaw.h
+++ b/src/vysmaw.h
@@ -25,6 +25,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
+#include <vys.h>
 
 #define VYSMAW_MULTICAST_ADDRESS_SIZE 32
 #define VYSMAW_DATA_DIGEST_SIZE 16

--- a/src/vysmaw_private.c
+++ b/src/vysmaw_private.c
@@ -337,10 +337,12 @@ digest_failure_message_new(vysmaw_handle handle,
 }
 
 struct vysmaw_message *
-end_message_new(vysmaw_handle handle, const struct vysmaw_result *rc)
+end_message_new(vysmaw_handle handle, struct vysmaw_result *rc)
 {
+	/* this steals ownership of rc->syserr_desc */
 	struct vysmaw_message *result = message_new(handle, VYSMAW_MESSAGE_END);
 	memcpy(&result->content.result, rc, sizeof(*rc));
+	rc->syserr_desc = NULL;
 	return result;
 }
 

--- a/src/vysmaw_private.h
+++ b/src/vysmaw_private.h
@@ -20,6 +20,7 @@
 
 #include <vysmaw.h>
 #include <vys.h>
+#include <vys_private.h>
 #include <buffer_pool.h>
 #include <glib.h>
 #include <infiniband/verbs.h>
@@ -73,6 +74,27 @@
 
 #define VERB_ERR(records, err, fn)                                      \
 	MSG_ERROR(records, err, "%s failed: %s", fn, strerror(err))
+
+/* vysmaw configuration file keys */
+#define VYSMAW_CONFIG_GROUP_NAME "vysmaw"
+#define SPECTRUM_BUFFER_POOL_SIZE_KEY "spectrum_buffer_pool_size"
+#define SINGLE_SPECTRUM_BUFFER_POOL_KEY "single_spectrum_buffer_pool"
+#define MAX_SPECTRUM_BUFFER_SIZE_KEY "max_spectrum_buffer_size"
+#define SIGNAL_MESSAGE_POOL_SIZE_KEY "signal_message_pool_size"
+#define EAGER_CONNECT_KEY "eager_connect"
+#define EAGER_CONNECT_IDLE_SEC_KEY "eager_connect_idle_sec"
+#define PRECONNECT_BACKLOG_KEY "preconnect_backlog"
+#define MAX_DEPTH_MESSAGE_QUEUE_KEY "max_depth_message_queue"
+#define QUEUE_RESUME_OVERHEAD_KEY "queue_resume_overhead"
+#define MAX_STARVATION_LATENCY_KEY "max_starvation_latency"
+#define RESOLVE_ROUTE_TIMEOUT_MS_KEY "resolve_route_timeout_ms"
+#define RESOLVE_ADDR_TIMEOUT_MS_KEY "resolve_addr_timeout_ms"
+#define INACTIVE_SERVER_TIMEOUT_SEC_KEY "inactive_server_timeout_sec"
+#define SHUTDOWN_CHECK_INTERVAL_MS_KEY "shutdown_check_interval_ms"
+#define SIGNAL_RECEIVE_MAX_POSTED_KEY "signal_receive_max_posted"
+#define SIGNAL_RECEIVE_MIN_ACK_PART_KEY "signal_receive_min_ack_part"
+#define RDMA_READ_MAX_POSTED_KEY "rdma_read_max_posted"
+#define RDMA_READ_MIN_ACK_PART_KEY "rdma_read_min_ack_part"
 
 struct _vysmaw_message_queue {
 	GAsyncQueue *q;
@@ -184,6 +206,12 @@ struct data_path_message {
 		};
 	};
 };
+
+extern char *config_vysmaw_base(void)
+	__attribute__((malloc,returns_nonnull));
+extern void init_from_key_file_vysmaw(
+	GKeyFile *kf, struct vysmaw_configuration *config)
+	__attribute__((nonnull));
 
 extern vysmaw_handle handle_ref(vysmaw_handle handle)
 	__attribute__((nonnull,returns_nonnull));

--- a/src/vysmaw_private.h
+++ b/src/vysmaw_private.h
@@ -71,11 +71,6 @@
 # define COND_SIGNAL(c) g_cond_signal(c)
 #endif
 
-#define MSG_ERROR(records, err, format, ...)                            \
-	{ *(records) = \
-	  vys_error_record_desc_dup_printf( \
-		  *(records), (err), G_STRLOC ": " format, ##__VA_ARGS__); }
-
 #define VERB_ERR(records, err, fn)                                      \
 	MSG_ERROR(records, err, "%s failed: %s", fn, strerror(err))
 

--- a/src/vysmaw_private.h
+++ b/src/vysmaw_private.h
@@ -323,7 +323,7 @@ extern struct vysmaw_message *digest_failure_message_new(
 	vysmaw_handle handle, const struct vysmaw_data_info *info)
 	__attribute__((malloc,returns_nonnull,nonnull));
 extern struct vysmaw_message *end_message_new(
-	vysmaw_handle handle, const struct vysmaw_result *rc)
+	vysmaw_handle handle, struct vysmaw_result *rc)
 	__attribute__((malloc,returns_nonnull,nonnull));
 extern struct vysmaw_message *queue_overflow_message_new(
 	vysmaw_handle handle, unsigned num_overflow)


### PR DESCRIPTION
Implementation of issue #2. The basic scheme is first, that "vys" (needed by both senders and receivers) and "vysmaw" (needed by vysmaw clients only) configuration parameters are identified by their section names in configuration files. Default configurations are provided by hard-coded values, which can be overridden by values in default configuration files (vys.conf and/or vysmaw.conf). Default configurations are always available assuming syntactically valid files; no error occurs if the system configuration files are not present. Users can also provide a configuration file name, which will provide values to override the default configuration; however, an error occurs if the named file does not exist. Getting a configuration for "vys" starts with the vys.conf file, and then whatever file is provided by the user. Getting a configuration for "vysmaw" starts with the "vys" configuration (with no user file), whose values are overridden by vysmaw.conf, which may subsequently be overridden by the user supplied file. While this scheme allows either the vysmaw.conf or a client-supplied file to have both "vys" and "vysmaw" sections, such configurations should only be used in exceptional circumstances, such as development and testing. In normal circumstances a vysmaw.conf and client-supplied files should only include a "vysmaw" section.