### PR TITLE
Add blocking wait on read requests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(vysmaw SHARED
   signal_receiver.c
   spectrum_selector.c
   spectrum_reader.c
+  async_queue.c
   vysmaw.c)
 target_include_directories(vysmaw PRIVATE
   ${GTHREAD2_INCLUDE_DIRS}

--- a/src/async_queue.c
+++ b/src/async_queue.c
@@ -1,0 +1,136 @@
+//
+// Copyright © 2016 Associated Universities, Inc. Washington DC, USA.
+//
+// This file is part of vysmaw.
+//
+// vysmaw is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// vysmaw is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// vysmaw.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <unistd.h>
+#include <errno.h>
+#ifndef _GNU_SOURCE
+# include <fcntl.h>
+#endif
+#include <string.h>
+#include <async_queue.h>
+
+#define POP_FD(q) ((q)->fds[0])
+#define PUSH_FD(q) ((q)->fds[1])
+
+struct async_queue *
+new_no_queue()
+{
+	struct async_queue *result = g_try_new(struct async_queue, 1);
+	if (G_LIKELY(result != NULL)) {
+		result->refcount = 1;
+		int rc;
+#ifdef _GNU_SOURCE
+		rc = pipe2(result->fds, O_NONBLOCK);
+#else
+		rc = pipe(result->fds);
+		if (G_LIKELY(rc == 0))
+			rc = fcntl(result->fds[0], F_SETFL, O_NONBLOCK);
+		if (G_LIKELY(rc == 0))
+			rc = fcntl(result->fds[1], F_SETFL, O_NONBLOCK);
+#endif
+		if (G_UNLIKELY(rc != 0)) {
+			g_free(result);
+			result = NULL;
+		}
+	} else {
+		errno = ENOMEM;
+	}
+	return result;
+}
+
+struct async_queue *
+async_queue_new()
+{
+	struct async_queue *result = new_no_queue();
+	if (G_LIKELY(result != NULL))
+		result->q = g_async_queue_new();
+	return result;
+}
+
+struct async_queue *
+async_queue_new_full(GDestroyNotify destroy)
+{
+	struct async_queue *result = new_no_queue();
+	if (G_LIKELY(result != NULL))
+		result->q = g_async_queue_new_full(destroy);
+	return result;
+}
+
+struct async_queue *
+async_queue_ref(struct async_queue *queue)
+{
+	g_atomic_int_inc(&queue->refcount);
+	return queue;
+}
+
+void
+async_queue_unref(struct async_queue *queue)
+{
+	if (g_atomic_int_dec_and_test(&queue->refcount)) {
+		g_async_queue_unref(queue->q);
+		int rc1 = close(queue->fds[0]);
+		int errno1 = errno;
+		int rc = close(queue->fds[1]);
+		if (G_UNLIKELY(rc == 0 && rc1 != 0))
+			errno = errno1;
+		g_free(queue);
+	}
+}
+
+void
+async_queue_push(struct async_queue *queue, void *item)
+{
+	g_async_queue_push(queue->q, item);
+	unsigned u;
+	size_t w = 0;
+	ssize_t n;
+	do {
+		errno = 0;
+		n = write(PUSH_FD(queue), (void *)&u + w, sizeof(u) - w);
+		if (G_LIKELY(n >= 0)) w += n;
+	} while (errno == EINTR || w != sizeof(u));
+	if (G_UNLIKELY(errno != 0))
+		g_error("async_queue_push write failed: %s", strerror(errno));
+}
+
+void *
+async_queue_pop(struct async_queue *queue)
+{
+	unsigned u;
+	size_t r = 0;
+	ssize_t n;
+	do {
+		errno = 0;
+		n = read(POP_FD(queue), (void *)&u + r, sizeof(u) - r);
+		if (G_LIKELY(n >= 0)) r += n;
+	} while (errno == EINTR || r != sizeof(u));
+	if (G_UNLIKELY(errno != 0))
+		g_error("async_queue_pop read failed: %s", strerror(errno));
+	return g_async_queue_pop(queue->q);
+}
+
+int
+async_queue_pop_fd(struct async_queue *queue)
+{
+	return POP_FD(queue);
+}
+
+int
+async_queue_push_fd(struct async_queue *queue)
+{
+	return PUSH_FD(queue);
+}

--- a/src/async_queue.h
+++ b/src/async_queue.h
@@ -1,0 +1,46 @@
+//
+// Copyright © 2016 Associated Universities, Inc. Washington DC, USA.
+//
+// This file is part of vysmaw.
+//
+// vysmaw is free software: you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// vysmaw is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// vysmaw.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef ASYNC_QUEUE_H_
+#define ASYNC_QUEUE_H_
+
+#include <glib.h>
+
+struct async_queue {
+	int refcount;
+	int fds[2];
+	GAsyncQueue *q;
+};
+
+extern struct async_queue *async_queue_new()
+	__attribute__((malloc));
+extern struct async_queue *async_queue_new_full(GDestroyNotify destroy)
+	__attribute__((nonnull,malloc));
+extern struct async_queue *async_queue_ref(struct async_queue *queue)
+	__attribute__((nonnull,returns_nonnull));
+extern void async_queue_unref(struct async_queue *queue)
+	__attribute__((nonnull));
+extern void async_queue_push(struct async_queue *queue, void *item)
+	__attribute__((nonnull));
+extern void *async_queue_pop(struct async_queue *queue)
+	__attribute__((nonnull,returns_nonnull));
+extern int async_queue_pop_fd(struct async_queue *queue)
+	__attribute__((nonnull));
+extern int async_queue_push_fd(struct async_queue *queue)
+	__attribute__((nonnull));
+
+#endif /* ASYNC_QUEUE_H_ */

--- a/src/spectrum_reader.h
+++ b/src/spectrum_reader.h
@@ -19,6 +19,7 @@
 #define SPECTRUM_READER_H_
 
 #include <vysmaw_private.h>
+#include <async_queue.h>
 
 struct spectrum_reader_context {
 	vysmaw_handle handle;
@@ -26,7 +27,7 @@ struct spectrum_reader_context {
 	unsigned signal_msg_num_spectra;
 	struct buffer_pool *signal_msg_buffers;
 
-	GAsyncQueue *read_request_queue;
+	struct async_queue *read_request_queue;
 
 	int loop_fd;
 };

--- a/src/spectrum_selector.c
+++ b/src/spectrum_selector.c
@@ -119,7 +119,7 @@ spectrum_selector(struct spectrum_selector_context *context)
 				}
 			}
 			if (selected) {
-				g_async_queue_push(context->read_request_queue, msg);
+				async_queue_push(context->read_request_queue, msg);
 			} else {
 				buffer_pool_push(context->signal_msg_buffers, msg->signal_msg);
 				data_path_message_free(msg);
@@ -128,23 +128,23 @@ spectrum_selector(struct spectrum_selector_context *context)
 		}
 		case DATA_PATH_QUIT:
 			quitting = true;
-			g_async_queue_push(context->read_request_queue, msg);
+			async_queue_push(context->read_request_queue, msg);
 			break;
 
 		case DATA_PATH_END:
 			quit = true;
-			g_async_queue_push(context->read_request_queue, msg);
+			async_queue_push(context->read_request_queue, msg);
 			break;
 
 		default:
-			g_async_queue_push(context->read_request_queue, msg);
+			async_queue_push(context->read_request_queue, msg);
 			break;
 		}
 	}
 
 	g_hash_table_destroy(prev_eagerly_forwarded);
 	g_async_queue_unref(context->signal_msg_queue);
-	g_async_queue_unref(context->read_request_queue);
+	async_queue_unref(context->read_request_queue);
 	g_free(context);
 	return NULL;
 }

--- a/src/spectrum_selector.h
+++ b/src/spectrum_selector.h
@@ -19,12 +19,13 @@
 #define SPECTRUM_SELECTOR_H_
 
 #include <vysmaw_private.h>
+#include <async_queue.h>
 
 struct spectrum_selector_context {
 	vysmaw_handle handle;
 
 	GAsyncQueue *signal_msg_queue;
-	GAsyncQueue *read_request_queue;
+	struct async_queue *read_request_queue;
 	struct buffer_pool *signal_msg_buffers;
 	unsigned signal_msg_num_spectra;
 };

--- a/src/vysmaw_private.c
+++ b/src/vysmaw_private.c
@@ -696,7 +696,7 @@ init_signal_receiver(vysmaw_handle handle, GAsyncQueue *signal_msg_queue,
 
 void
 init_spectrum_selector(vysmaw_handle handle, GAsyncQueue *signal_msg_queue,
-                       GAsyncQueue *read_request_queue,
+                       struct async_queue *read_request_queue,
                        struct buffer_pool *signal_msg_buffers,
                        unsigned signal_msg_num_spectra)
 {
@@ -704,7 +704,7 @@ init_spectrum_selector(vysmaw_handle handle, GAsyncQueue *signal_msg_queue,
 		g_new(struct spectrum_selector_context, 1);
 	context->handle = handle;
 	context->signal_msg_queue = g_async_queue_ref(signal_msg_queue);
-	context->read_request_queue = g_async_queue_ref(read_request_queue);
+	context->read_request_queue = async_queue_ref(read_request_queue);
 	context->signal_msg_buffers = signal_msg_buffers;
 	context->signal_msg_num_spectra = signal_msg_num_spectra;
 	handle->spectrum_selector_thread =
@@ -713,7 +713,8 @@ init_spectrum_selector(vysmaw_handle handle, GAsyncQueue *signal_msg_queue,
 }
 
 void
-init_spectrum_reader(vysmaw_handle handle, GAsyncQueue *read_request_queue,
+init_spectrum_reader(vysmaw_handle handle,
+                     struct async_queue *read_request_queue,
                      struct buffer_pool *signal_msg_buffers,
                      unsigned signal_msg_num_spectra, int loop_fd)
 {
@@ -723,7 +724,7 @@ init_spectrum_reader(vysmaw_handle handle, GAsyncQueue *read_request_queue,
 	context->loop_fd = loop_fd;
 	context->signal_msg_buffers = signal_msg_buffers;
 	context->signal_msg_num_spectra = signal_msg_num_spectra;
-	context->read_request_queue = g_async_queue_ref(read_request_queue);
+	context->read_request_queue = async_queue_ref(read_request_queue);
 	handle->spectrum_reader_thread =
 		THREAD_NEW("spectrum_reader", (GThreadFunc)spectrum_reader,
 		           context);
@@ -758,7 +759,7 @@ init_service_threads(vysmaw_handle handle)
 	init_signal_receiver(handle, signal_msg_queue, &signal_msg_buffers,
 	                     &signal_msg_num_spectra, loop_fds[0]);
 
-	GAsyncQueue *read_request_queue = g_async_queue_new();
+	struct async_queue *read_request_queue = async_queue_new();
 	init_spectrum_selector(handle, signal_msg_queue, read_request_queue,
 	                       signal_msg_buffers, signal_msg_num_spectra);
 
@@ -768,7 +769,7 @@ init_service_threads(vysmaw_handle handle)
 	MUTEX_UNLOCK(handle->gate.mtx);
 
 	g_async_queue_unref(signal_msg_queue);
-	g_async_queue_unref(read_request_queue);
+	async_queue_unref(read_request_queue);
 
 	return 0;
 }

--- a/src/vysmaw_private.h
+++ b/src/vysmaw_private.h
@@ -22,6 +22,7 @@
 #include <vys.h>
 #include <vys_private.h>
 #include <buffer_pool.h>
+#include <async_queue.h>
 #include <glib.h>
 #include <infiniband/verbs.h>
 #include <rdma/rdma_verbs.h>
@@ -271,11 +272,12 @@ extern void init_signal_receiver(
 	__attribute__((nonnull));
 extern void init_spectrum_selector(
 	vysmaw_handle handle, GAsyncQueue *signal_msg_queue,
-	GAsyncQueue *read_request_queue, struct buffer_pool *signal_msg_buffers,
+	struct async_queue *read_request_queue,
+	struct buffer_pool *signal_msg_buffers,
 	unsigned signal_msg_num_spectra)
 	__attribute__((nonnull));
 extern void init_spectrum_reader(
-	vysmaw_handle handle, GAsyncQueue *read_request_queue,
+	vysmaw_handle handle, struct async_queue *read_request_queue,
 	struct buffer_pool *signal_msg_buffers, unsigned signal_msg_num_spectra,
 	int loop_fd)
 	__attribute__((nonnull));


### PR DESCRIPTION
Implement an asynchronous queue associated with a file descriptor, which is used
for the queue of read requests between the spectrum_selector and the
spectrum_reader threads. This allows the main loop in spectrum_reader to block
for input on the queue in its call to poll().