### PR TITLE
Replace buffer digest with sequence number

### DIFF
--- a/examples/sample4.cc
+++ b/examples/sample4.cc
@@ -82,7 +82,7 @@ show_counters(array<unsigned,VYSMAW_MESSAGE_END + 1> &counters)
 {
 	const unordered_map<enum vysmaw_message_type,string> names = {
 		{VYSMAW_MESSAGE_VALID_BUFFER, "valid-buffer"},
-		{VYSMAW_MESSAGE_DIGEST_FAILURE, "digest-failure"},
+		{VYSMAW_MESSAGE_ID_FAILURE, "id-failure"},
 		{VYSMAW_MESSAGE_QUEUE_OVERFLOW, "queue-overflow"},
 		{VYSMAW_MESSAGE_DATA_BUFFER_STARVATION, "data-buffer-starvation"},
 		{VYSMAW_MESSAGE_SIGNAL_BUFFER_STARVATION, "signal-buffer-starvation"},
@@ -99,7 +99,7 @@ show_counters(array<unsigned,VYSMAW_MESSAGE_END + 1> &counters)
 
 	const enum vysmaw_message_type msg_types[] = {
 		VYSMAW_MESSAGE_VALID_BUFFER,
-		VYSMAW_MESSAGE_DIGEST_FAILURE,
+		VYSMAW_MESSAGE_ID_FAILURE,
 		VYSMAW_MESSAGE_QUEUE_OVERFLOW,
 		VYSMAW_MESSAGE_DATA_BUFFER_STARVATION,
 		VYSMAW_MESSAGE_SIGNAL_BUFFER_STARVATION,

--- a/py/cy_vysmaw.pyx
+++ b/py/cy_vysmaw.pyx
@@ -417,6 +417,10 @@ cdef class DataInfo:
         return result
 
     @property
+    def id_num(self):
+        return self._c_info[0].id_num
+
+    @property
     def config_id(self):
         return self._c_info[0].config_id
 
@@ -496,8 +500,8 @@ cdef class Message:
         msgtype = msg[0].typ
         if msgtype == VYSMAW_MESSAGE_VALID_BUFFER:
             result = ValidBufferMessage()
-        elif msgtype == VYSMAW_MESSAGE_DIGEST_FAILURE:
-            result = DigestFailureMessage()
+        elif msgtype == VYSMAW_MESSAGE_ID_FAILURE:
+            result = IdFailureMessage()
         elif msgtype == VYSMAW_MESSAGE_QUEUE_OVERFLOW:
             result = QueueOverflowMessage()
         elif msgtype == VYSMAW_MESSAGE_DATA_BUFFER_STARVATION:
@@ -536,22 +540,18 @@ cdef class ValidBufferMessage(Message):
         return DataInfo.wrap(&(self._c_message[0].content.valid_buffer.info))
 
     @property
-    def buffer_size(self):
-        return self._c_message[0].content.valid_buffer.buffer_size
+    def spectrum(self):
+        n = (self.buffer_size - VYS_SPECTRUM_OFFSET) / sizeof(float)
+        return <float[:n]>self._c_message[0].content.valid_buffer.spectrum
 
-    @property
-    def buffer(self):
-        n = self.buffer_size / sizeof(float)
-        return <float[:n]>self._c_message[0].content.valid_buffer.buffer
-
-cdef class DigestFailureMessage(Message):
+cdef class IdFailureMessage(Message):
 
     def __str__(self):
-        return show_properties(self, DigestFailureMessage)
+        return show_properties(self, IdFailureMessage)
 
     @property
     def info(self):
-        return DataInfo.wrap(&(self._c_message[0].content.digest_failure))
+        return DataInfo.wrap(&(self._c_message[0].content.id_failure))
 
 cdef class QueueOverflowMessage(Message):
 

--- a/py/vysmaw.pxd
+++ b/py/vysmaw.pxd
@@ -22,25 +22,25 @@ from libcpp cimport bool
 
 cdef extern from "vysmaw.h":
 
-    DEF VYS_DATA_DIGEST_SIZE = 16
+    int VYS_SPECTRUM_OFFSET = 16
 
     DEF VYS_MULTICAST_ADDRESS_SIZE = 32
 
     DEF VYS_CONFIG_ID_SIZE = 32
 
-    DEF VYS_POLARIZATION_PRODUCT_AA = 0
-    DEF VYS_POLARIZATION_PRODUCT_AB = 1
-    DEF VYS_POLARIZATION_PRODUCT_BA = 2
-    DEF VYS_POLARIZATION_PRODUCT_BB = 3
-    DEF VYS_POLARIZATION_PRODUCT_UNKNOWN = 4
+    int VYS_POLARIZATION_PRODUCT_AA = 0
+    int VYS_POLARIZATION_PRODUCT_AB = 1
+    int VYS_POLARIZATION_PRODUCT_BA = 2
+    int VYS_POLARIZATION_PRODUCT_BB = 3
+    int VYS_POLARIZATION_PRODUCT_UNKNOWN = 4
 
-    DEF VYS_BASEBAND_A1C1_3BIT = 0
-    DEF VYS_BASEBAND_A2C2_3BIT = 1
-    DEF VYS_BASEBAND_AC_8BIT = 2
-    DEF VYS_BASEBAND_B1D1_3BIT = 3
-    DEF VYS_BASEBAND_B2D2_3BIT = 4
-    DEF VYS_BASEBAND_BD_8BIT = 5
-    DEF VYS_BASEBAND_UNKNOWN = 6
+    int VYS_BASEBAND_A1C1_3BIT = 0
+    int VYS_BASEBAND_A2C2_3BIT = 1
+    int VYS_BASEBAND_AC_8BIT = 2
+    int VYS_BASEBAND_B1D1_3BIT = 3
+    int VYS_BASEBAND_B2D2_3BIT = 4
+    int VYS_BASEBAND_BD_8BIT = 5
+    int VYS_BASEBAND_UNKNOWN = 6
 
     DEF VYSMAW_RECEIVE_STATUS_LENGTH = 64
 
@@ -83,7 +83,7 @@ cdef extern from "vysmaw.h":
     struct vys_spectrum_info:
         uint64_t data_addr
         uint64_t timestamp
-        uint8_t digest[VYS_DATA_DIGEST_SIZE]
+        uint32_t id_num
 
     enum result_code:
         VYSMAW_NO_ERROR,
@@ -102,7 +102,7 @@ cdef extern from "vysmaw.h":
 
     enum vysmaw_message_type:
         VYSMAW_MESSAGE_VALID_BUFFER,
-        VYSMAW_MESSAGE_DIGEST_FAILURE,
+        VYSMAW_MESSAGE_ID_FAILURE,
         VYSMAW_MESSAGE_QUEUE_OVERFLOW,
         VYSMAW_MESSAGE_DATA_BUFFER_STARVATION,
         VYSMAW_MESSAGE_SIGNAL_BUFFER_STARVATION,
@@ -115,11 +115,13 @@ cdef extern from "vysmaw.h":
     struct message_valid_buffer:
         vysmaw_data_info info
         stddef.size_t buffer_size
-        float *buffer
+        void *buffer
+        uint32_t *id_num
+        float *spectrum
 
     union message_content:
         message_valid_buffer valid_buffer
-        vysmaw_data_info digest_failure
+        vysmaw_data_info id_failure
         unsigned num_overflow
         unsigned num_data_buffers_unavailable
         unsigned num_signal_buffers_unavailable

--- a/src/vys.h
+++ b/src/vys.h
@@ -32,16 +32,16 @@ extern "C" {
 #include <linux/if_packet.h>
 #include <linux/if_arp.h>
 
-#define VYS_VERSION 2
+#define VYS_VERSION 3
 
 #define VYS_MULTICAST_ADDRESS_SIZE 32
-#define VYS_DATA_DIGEST_SIZE 16
 #define VYS_CONFIG_ID_SIZE 32
+#define VYS_SPECTRUM_OFFSET 16
 
 struct vys_spectrum_info {
 	uint64_t data_addr;
 	uint64_t timestamp;
-	uint8_t digest[VYS_DATA_DIGEST_SIZE];
+	uint32_t id_num;
 };
 
 /* polarization product definitions

--- a/src/vysmaw.h
+++ b/src/vysmaw.h
@@ -226,7 +226,7 @@ typedef struct _vysmaw_handle *vysmaw_handle;
  */
 enum vysmaw_message_type {
 	VYSMAW_MESSAGE_VALID_BUFFER,
-	VYSMAW_MESSAGE_DIGEST_FAILURE, // failed to verify buffer digest
+	VYSMAW_MESSAGE_ID_FAILURE, // failed to verify id number
 	VYSMAW_MESSAGE_QUEUE_OVERFLOW, // message queue overflow
 	VYSMAW_MESSAGE_DATA_BUFFER_STARVATION, // data buffers unavailable
 	VYSMAW_MESSAGE_SIGNAL_BUFFER_STARVATION, // signal buffers unavailable
@@ -250,11 +250,13 @@ struct vysmaw_message {
 		struct {
 			struct vysmaw_data_info info;
 			size_t buffer_size;
-			float *buffer;
+			void *buffer;
+			uint32_t *id_num;
+			float *spectrum;
 		} valid_buffer;
 
-		/* VYSMAW_MESSAGE_DIGEST_FAILURE */
-		struct vysmaw_data_info digest_failure;
+		/* VYSMAW_MESSAGE_ID_FAILURE */
+		struct vysmaw_data_info id_failure;
 
 		/* VYSMAW_MESSAGE_QUEUE_OVERFLOW */
 		unsigned num_overflow;

--- a/src/vysmaw_private.h
+++ b/src/vysmaw_private.h
@@ -306,7 +306,7 @@ extern struct vysmaw_message *signal_buffer_starvation_message_new(
 extern struct vysmaw_message *signal_receive_queue_underflow_message_new(
 	vysmaw_handle handle)
 	__attribute__((nonnull,returns_nonnull));
-extern struct vysmaw_message *digest_failure_message_new(
+extern struct vysmaw_message *id_failure_message_new(
 	vysmaw_handle handle, const struct vysmaw_data_info *info)
 	__attribute__((malloc,returns_nonnull,nonnull));
 extern struct vysmaw_message *end_message_new(
@@ -369,10 +369,10 @@ extern void mark_version_mismatch(
 extern void mark_signal_receive_queue_underflow(vysmaw_handle handle)
 	__attribute__((nonnull));
 
-static inline size_t spectrum_size(const struct vysmaw_data_info *info)
+static inline size_t buffer_size(const struct vysmaw_data_info *info)
 {
 	return 2 * ((info->num_bins - 1) * info->bin_stride + info->num_channels)
-		* sizeof(float);
+		* sizeof(float) + VYS_SPECTRUM_OFFSET;
 }
 
 extern int register_one_spectrum_buffer_pool(
@@ -397,7 +397,7 @@ extern void free_sockaddr_key(
 	struct sockaddr_in *sockaddr)
 	__attribute__((nonnull));
 
-extern void convert_valid_to_digest_failure(struct vysmaw_message *message)
+extern void convert_valid_to_id_failure(struct vysmaw_message *message)
 	__attribute__((nonnull));
 extern void convert_valid_to_rdma_read_failure(
 	struct vysmaw_message *message, enum ibv_wc_status status)


### PR DESCRIPTION
Conforms to vys protocol version 3, which replaces the buffer digests with sequence numbers.